### PR TITLE
multiple vswitch prov, hardcoded to vars.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,8 +6,11 @@ provider "alicloud" {
 
 module "vpc" {
   source       = "./vpc"
-  vpc_name     = "kwoodson-vpc"
-  vswitch_name = "kwoodson-vswitch"
+  vpc_name     = var.vpc_name
+  vpc_cidr     = var.vpc_cidr
+  vsw_name     = var.vsw_name
+  vsw_cidrs    = var.vsw_cidrs
+  zone_id      = var.zone_id
 }
 
 module "oss" {

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,35 @@ variable "account_id" {
   //sensitive = true
 }
 
+variable "vpc_name" {
+  type      = string
+}
+
+variable "vpc_cidr" {
+  type      = string
+}
+
+variable "vsw_name" {
+  type      = string
+}
+
+variable "vsw_cidrs" {
+  type      = list(any)
+}
+
+variable "zone_id" {
+  type      = list(any)
+}
+
+variable "use_num_suffix" {
+  type        = bool
+  default     = false
+}
+
+variable "region" {
+  type = string
+}
+
 variable "public_domain" {
   type = string
 }
@@ -26,10 +55,6 @@ variable "bootstrap_instance_type" {
 }
 
 variable "worker_instance_type" {
-  type = string
-}
-
-variable "region" {
   type = string
 }
 

--- a/vpc/outputs.tf
+++ b/vpc/outputs.tf
@@ -3,5 +3,5 @@ output "vpc_id" {
 }
 
 output "vswitch_id" {
-  value = alicloud_vswitch.vsw.id
+  value = alicloud_vswitch.vsw.*.id
 }

--- a/vpc/variables.tf
+++ b/vpc/variables.tf
@@ -1,7 +1,24 @@
-variable "vswitch_name" {
+variable "vsw_name" {
   type = string
 }
 
 variable "vpc_name" {
   type = string
+}
+
+variable "vpc_cidr" {
+  type = string
+}
+
+variable "vsw_cidrs" {
+  type      = list(any)
+}
+
+variable "zone_id" {
+  type      = list(any)
+}
+
+variable "use_num_suffix" {
+  type        = bool
+  default     = false
 }

--- a/vpc/vpc.tf
+++ b/vpc/vpc.tf
@@ -1,11 +1,12 @@
 resource "alicloud_vpc" "vpc" {
   vpc_name   = var.vpc_name
-  cidr_block = "192.168.0.0/16"
+  cidr_block = var.vpc_cidr
 }
 
 resource "alicloud_vswitch" "vsw" {
-  vswitch_name = var.vswitch_name
+  count        = length(var.vsw_cidrs)
+  vswitch_name = length(var.vsw_cidrs) > 1 || var.use_num_suffix ? format("%s%03d", var.vsw_name, count.index + 1) : var.vsw_name
   vpc_id       = alicloud_vpc.vpc.id
-  cidr_block   = "192.168.1.0/24"
-  zone_id      = "us-east-a"
+  cidr_block   = var.vsw_cidrs[count.index]
+  zone_id      = element(var.zone_id, count.index)
 }


### PR DESCRIPTION
* add ability to prov multiple vswitches based on subnets provided
E.g in the vars file:
vswitch_cidrs = ["192.168.1.0/24", "192.168.2.0/24"]
zone_id = ["ap-southeast-3a", "ap-southeast-3b"]

* change some hardcoded value to vars